### PR TITLE
Separate matchers and delimiters

### DIFF
--- a/lib/pattern/index.js
+++ b/lib/pattern/index.js
@@ -11,7 +11,7 @@ const STATS = 'stats\\[(.*)\\]';
 const SEARCH_TYPE = 'search_type\\[(.*)\\]';
 const TOTAL_SHARDS = 'total_shards\\[(\\d+)\\]';
 const QUERY = 'source\\[(.*)\\]';
-
+const delimiter = '(?:,?\\s*)';
 
 const matchers = [
     TIMESTAMP,
@@ -30,6 +30,7 @@ const matchers = [
 ];
 
 module.exports = {
-    pattern: new RegExp(matchers.join('(?:,?\\s*)')),
-    matchers
+    pattern: new RegExp(matchers.join(delimiter)),
+    matchers,
+    delimiter
 };

--- a/lib/pattern/spec.js
+++ b/lib/pattern/spec.js
@@ -1,8 +1,8 @@
-const {pattern, matchers} = require('.');
+const {pattern, matchers, delimiter} = require('.');
 
 describe('ES/pattern', () => {
     test('Should create a patterns comprised of all matchers', () => {
-        expect(pattern.source).toEqual(matchers.join('(?:,?\\s*)'));
+        expect(pattern.source).toEqual(matchers.join(delimiter));
     });
 
     const [
@@ -21,6 +21,12 @@ describe('ES/pattern', () => {
         query
     ] = matchers.map((part) => new RegExp(part));
 
+    describe('delimiter', () => {
+        test('Should extract timestamp', () => {
+            const [, ...matches] = new RegExp(new Array(4).fill('(\\w)').join(delimiter)).exec('a,b, c   d');
+            expect(matches).toEqual(['a', 'b', 'c', 'd']);
+        });
+    });
     describe('timestamp', () => {
         test('Should extract timestamp', () => {
             const [, match] = timestamp.exec('[2019-09-04T14:17:34,160]');


### PR DESCRIPTION
Continuing [my comment](https://github.com/fiverr/node-es-slow-log-parse/pull/1#issuecomment-528483410) from #1:

> I feel like the matchers could contain the match item only, and remove the commas and spaces from their match structure to be delimiters:
> `(?:,{0,1}\\s*)` - A non capturing group consisting of:
> - ~0 or 1 comma~ optional comma
> - 0 or more spaces

If you choose to merge this pull request - it will merge into your feature branch